### PR TITLE
Add different type checkers

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ def count_words(arg: list[str]) -> int:
     return sum(len(text.split()) for text in arg)
 
 
-@overtake
+@overtake(runtime_type_checker="beartype")
 def count_words(arg):
     ...
 
@@ -65,7 +65,7 @@ print(count_words(["one two", "three four five six"]))
 
 Overtake will analyse the types and provided arguments to call the right implementation.
 
-It works for every type hint supported by the awesome [beartype](https://beartype.readthedocs.io/en/latest/).
+It works for every type hint supported by the awesome [beartype]().
 It works for every signature supported by [`@typing.overload`](https://docs.python.org/3/library/typing.html#typing.overload)
 
 This pattern is supported by IDEs (Pycharm, VSCode, etc...) so autocompletion will work well.
@@ -129,7 +129,7 @@ def count_words(input_value: list[str]) -> int:
     return sum(count_words(text) for text in input_value)
 
 
-@overtake
+@overtake(runtime_type_checker="beartype")
 def count_words(input_value):
     ...
 
@@ -161,7 +161,7 @@ def convert_to_int(input_value: list[str]) -> list[int]:
     return [int(x) for x in input_value]
 
 
-@overtake
+@overtake(runtime_type_checker="beartype")
 def convert_to_int(input_value):
     ...
 
@@ -212,7 +212,7 @@ def write_text_to_file(text: str) -> Path:
     return write_text_to_file(text, random_file_name)
 
 
-@overtake
+@overtake(runtime_type_checker="beartype")
 def write_text_to_file(text, file=None):
     ...
 
@@ -267,6 +267,29 @@ Overtake does this for you!
 
 We recommend using a type checker of your choice (Mypy, Pyright, etc...) so that the type checker catches
 invalid usages of `@overload`. Even though it's not mandatory, it's helpful to catch mistakes with `@overload` early.
+
+
+## The argument `runtime_type_checker`
+
+Runtime type checking in Python is difficult. Actually, very difficult. A few libraries provide this functionality, like
+[beartype](https://beartype.readthedocs.io/en/latest/) or [pydantic](https://docs.pydantic.dev/latest/).
+
+To avoid having to install any dependency, `overtake` can use `isinstance` as the default "basic" type checker.
+Note that this will only work with types that are classes. For example, it won't work with `list[str]`.
+
+To handle more complicated types, you should use
+
+```python
+@overtake(runtime_type_checker="beartype")
+def find_user_balance(*, user_id=None, name=None):
+    ...
+```
+or
+```python
+@overtake(runtime_type_checker="pydantic")
+def find_user_balance(*, user_id=None, name=None):
+    ...
+```
 
 ## Compatibility with Pyright
 

--- a/README.md
+++ b/README.md
@@ -274,7 +274,8 @@ Runtime type checking in Python is difficult. Actually, very difficult. A few li
 [beartype](https://beartype.readthedocs.io/en/latest/) or [pydantic](https://docs.pydantic.dev/latest/).
 
 To avoid having to install any dependency, `overtake` can use `isinstance` as the default `"basic"` type checker.
-Note that this will only work with types that are classes. For example, it won't work with `list[str]`.
+Note that this will only work with types that are classes. For example, it won't work with `list[str]` but it will work with `list` or
+`datetime`.
 
 To handle more complicated types, you should use
 
@@ -293,7 +294,7 @@ def find_user_balance(*, user_id=None, name=None):
 ####  What `runtime_type_checker` do I need? There are so many choices!!!
 
 First of all, don't pick any (`"basic"` will be used by default) and see if it works.
-If the types you are using are too complicated,
+If the types you are using are too complicated (if you are using generics or protocols),
 overtake will raise an error and tell you to use another `runtime_type_checker`.
 
 Then you have the choice between `"beartype"` and `"pydantic"`. Ask yourself the question,
@@ -302,6 +303,7 @@ If yes, use beartype.
 
 If not, ask yourself the question
 "Do I need Pydantic's specific types? Like [Pydantic's urls or custom types](https://docs.pydantic.dev/latest/usage/types/custom/#custom-data-types)?"
+If yes, use pydantic.
 
 If you are still undecided after this, you should use beartype as it's faster (validate in O(1)), but beware,
 you might get silent errors for unsupported types, and it might be really unpleasant.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ print(count_words(["one two", "three four five six"]))
 
 Overtake will analyse the types and provided arguments to call the right implementation.
 
-It works for every type hint supported by the awesome [beartype]().
 It works for every signature supported by [`@typing.overload`](https://docs.python.org/3/library/typing.html#typing.overload)
 
 This pattern is supported by IDEs (Pycharm, VSCode, etc...) so autocompletion will work well.
@@ -230,7 +229,7 @@ print(write_text_to_file("hello world", io.StringIO()))
 ### Leveraging keyword arguments
 
 You can use this paradigm to force the user to use less arguments than the number defined in the function.
-Here is an example where you'll looking for the balance of a user. You can provide the user id, or the user name,
+Here is an example where you're looking for the balance of a user. You can provide the user id, or the user's name,
 but not both.
 
 ```python
@@ -274,7 +273,7 @@ invalid usages of `@overload`. Even though it's not mandatory, it's helpful to c
 Runtime type checking in Python is difficult. Actually, very difficult. A few libraries provide this functionality, like
 [beartype](https://beartype.readthedocs.io/en/latest/) or [pydantic](https://docs.pydantic.dev/latest/).
 
-To avoid having to install any dependency, `overtake` can use `isinstance` as the default "basic" type checker.
+To avoid having to install any dependency, `overtake` can use `isinstance` as the default `"basic"` type checker.
 Note that this will only work with types that are classes. For example, it won't work with `list[str]`.
 
 To handle more complicated types, you should use

--- a/README.md
+++ b/README.md
@@ -290,6 +290,25 @@ def find_user_balance(*, user_id=None, name=None):
     ...
 ```
 
+####  What `runtime_type_checker` do I need? There are so many choices!!!
+
+First of all, don't pick any (`"basic"` will be used by default) and see if it works.
+If the types you are using are too complicated,
+overtake will raise an error and tell you to use another `runtime_type_checker`.
+
+Then you have the choice between `"beartype"` and `"pydantic"`. Ask yourself the question,
+"Do I need beartype-specific types? Like [beartype's validators](https://beartype.readthedocs.io/en/latest/api_vale/)?"
+If yes, use beartype.
+
+If not, ask yourself the question
+"Do I need Pydantic's specific types? Like [Pydantic's urls or custom types](https://docs.pydantic.dev/latest/usage/types/custom/#custom-data-types)?"
+
+If you are still undecided after this, you should use beartype as it's faster (validate in O(1)), but beware,
+you might get silent errors for unsupported types, and it might be really unpleasant. Pydantic might be slower, but you'll
+get errors when using an unsupported type. So it's safer.
+
+Both are really cool libraries, I encourage any curious mind to go read those docs!
+
 ## Compatibility with Pyright
 
 Pyright has a small compatibility issue, you might get the following error:

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 pip install overtake
 ```
 
+Overtake is quite self-contained. The only dependency, by default, is `typing-extensions`.
+
 ## What is Overtake?
 
 Have you ever dreamed of declaring the same function multiple times?

--- a/examples/simplest_example_beartype.py
+++ b/examples/simplest_example_beartype.py
@@ -20,7 +20,7 @@ def is_this_string_big(arg: LengthyString) -> str:  # type: ignore
 
 
 @overtake(runtime_type_checker="beartype")
-def is_this_string_big(arg):
+def is_this_string_big(arg):  # type: ignore
     ...
 
 

--- a/examples/simplest_example_beartype.py
+++ b/examples/simplest_example_beartype.py
@@ -1,0 +1,31 @@
+from typing import Annotated, overload
+
+from beartype.vale import Is
+from overtake import overtake
+
+# Type hint matching only strings with lengths ranging [4, 40].
+LengthyString = Annotated[str, Is[lambda text: 4 <= len(text) < 40]]
+
+# Type hint matching only strings with lengths ranging [0, 4].
+ShortString = Annotated[str, Is[lambda text: 0 <= len(text) < 4]]
+
+
+@overload
+def is_this_string_big(arg: ShortString) -> str:  # type: ignore
+    return "This is a short string!"
+
+
+@overload
+def is_this_string_big(arg: LengthyString) -> str:  # type: ignore
+    return "This is a very long string"
+
+
+@overtake(runtime_type_checker="beartype")
+def is_this_string_big(arg):
+    ...
+
+
+print(is_this_string_big("Hi!"))
+# This is a short string!
+print(is_this_string_big("No one expects the spanish inquisition!"))
+# This is a very long string

--- a/examples/simplest_example_beartype.py
+++ b/examples/simplest_example_beartype.py
@@ -1,7 +1,6 @@
-from typing import Annotated, overload
-
 from beartype.vale import Is
 from overtake import overtake
+from typing_extensions import Annotated, overload
 
 # Type hint matching only strings with lengths ranging [4, 40].
 LengthyString = Annotated[str, Is[lambda text: 4 <= len(text) < 40]]

--- a/examples/simplest_example_pydantic.py
+++ b/examples/simplest_example_pydantic.py
@@ -18,7 +18,7 @@ def connect(arg):
     ...
 
 
-print(connect("rediss://:pass@localhost"))
+print(connect("rediss://:pass@localhost"))  # type: ignore
 # Connected to redis!
-print(connect("mongodb://mongodb0.example.com:27017"))
+print(connect("mongodb://mongodb0.example.com:27017"))  # type: ignore
 # Connected to MongoDB!

--- a/examples/simplest_example_pydantic.py
+++ b/examples/simplest_example_pydantic.py
@@ -1,0 +1,25 @@
+from typing import overload
+
+from overtake import overtake
+from pydantic import MongoDsn, RedisDsn
+
+
+@overload
+def connect(arg: RedisDsn) -> str:  # type: ignore
+    return "Connected to redis!"
+
+
+@overload
+def connect(arg: MongoDsn) -> str:  # type: ignore
+    return "Connected to MongoDB!"
+
+
+@overtake(runtime_type_checker="pydantic")
+def connect(arg):
+    ...
+
+
+print(connect("rediss://:pass@localhost"))
+# Connected to redis!
+print(connect("mongodb://mongodb0.example.com:27017"))
+# Connected to MongoDB!

--- a/examples/simplest_example_pydantic.py
+++ b/examples/simplest_example_pydantic.py
@@ -1,7 +1,6 @@
-from typing import overload
-
 from overtake import overtake
 from pydantic import MongoDsn, RedisDsn
+from typing_extensions import overload
 
 
 @overload

--- a/examples/simplest_example_pydantic.py
+++ b/examples/simplest_example_pydantic.py
@@ -14,7 +14,7 @@ def connect(arg: MongoDsn) -> str:  # type: ignore
 
 
 @overtake(runtime_type_checker="pydantic")
-def connect(arg):
+def connect(arg):  # type: ignore
     ...
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,12 +6,21 @@ authors = [
     { name = "Gabriel de Marmiesse", email = "gabrieldemarmiesse@gmail.com" }
 ]
 dependencies = [
-    "beartype>=0.12.0,<1",
     "typing-extensions>=4.7.0, <5",
 ]
 license = { text = "MIT" }
 readme = "README.md"
 requires-python = ">= 3.8"
+
+[project.optional-dependencies]
+
+beartype = [
+    "beartype>=0.12.0,<1",
+]
+pydantic = [
+    "pydantic>=2.0,<3"
+]
+
 
 [build-system]
 requires = ["hatchling"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "overtake"
-version = "0.3.0"
+version = "0.4.0"
 description = "A runtime implementation of @typing.overload."
 authors = [
     { name = "Gabriel de Marmiesse", email = "gabrieldemarmiesse@gmail.com" }

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -4,9 +4,11 @@
 # last locked with the following flags:
 #   pre: false
 #   features: []
-#   all-features: false
+#   all-features: true
 
 -e file:.
+annotated-types==0.5.0
+beartype==0.15.0
 bleach==6.0.0
 build==1.0.0
 certifi==2023.7.22
@@ -37,6 +39,8 @@ platformdirs==3.10.0
 pluggy==1.3.0
 pre-commit==3.4.0
 pycparser==2.21
+pydantic==2.3.0
+pydantic-core==2.6.3
 pygments==2.16.1
 pyproject-hooks==1.0.0
 pyright==1.1.325

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -4,9 +4,10 @@
 # last locked with the following flags:
 #   pre: false
 #   features: []
-#   all-features: false
+#   all-features: true
 
 -e file:.
+annotated-types==0.5.0
 beartype==0.15.0
 bleach==6.0.0
 build==1.0.0
@@ -17,12 +18,10 @@ charset-normalizer==3.2.0
 cryptography==41.0.3
 distlib==0.3.7
 docutils==0.20.1
-exceptiongroup==1.1.3
 filelock==3.12.3
 identify==2.5.27
 idna==3.4
 importlib-metadata==6.8.0
-importlib-resources==6.0.1
 iniconfig==2.0.0
 jaraco-classes==3.3.0
 jeepney==0.8.0
@@ -40,6 +39,8 @@ platformdirs==3.10.0
 pluggy==1.3.0
 pre-commit==3.4.0
 pycparser==2.21
+pydantic==2.3.0
+pydantic-core==2.6.3
 pygments==2.16.1
 pyproject-hooks==1.0.0
 pyright==1.1.325
@@ -52,7 +53,6 @@ rfc3986==2.0.0
 rich==13.5.2
 secretstorage==3.3.3
 six==1.16.0
-tomli==2.0.1
 twine==4.0.2
 typing-extensions==4.7.1
 urllib3==2.0.4

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -4,11 +4,9 @@
 # last locked with the following flags:
 #   pre: false
 #   features: []
-#   all-features: true
+#   all-features: false
 
 -e file:.
-annotated-types==0.5.0
-beartype==0.15.0
 bleach==6.0.0
 build==1.0.0
 certifi==2023.7.22
@@ -39,8 +37,6 @@ platformdirs==3.10.0
 pluggy==1.3.0
 pre-commit==3.4.0
 pycparser==2.21
-pydantic==2.3.0
-pydantic-core==2.6.3
 pygments==2.16.1
 pyproject-hooks==1.0.0
 pyright==1.1.325

--- a/requirements.lock
+++ b/requirements.lock
@@ -4,7 +4,11 @@
 # last locked with the following flags:
 #   pre: false
 #   features: []
-#   all-features: false
+#   all-features: true
 
 -e file:.
+annotated-types==0.5.0
+beartype==0.15.0
+pydantic==2.3.0
+pydantic-core==2.6.3
 typing-extensions==4.7.1

--- a/requirements.lock
+++ b/requirements.lock
@@ -4,11 +4,7 @@
 # last locked with the following flags:
 #   pre: false
 #   features: []
-#   all-features: true
+#   all-features: false
 
 -e file:.
-annotated-types==0.5.0
-beartype==0.15.0
-pydantic==2.3.0
-pydantic-core==2.6.3
 typing-extensions==4.7.1

--- a/requirements.lock
+++ b/requirements.lock
@@ -4,8 +4,11 @@
 # last locked with the following flags:
 #   pre: false
 #   features: []
-#   all-features: false
+#   all-features: true
 
 -e file:.
+annotated-types==0.5.0
 beartype==0.15.0
+pydantic==2.3.0
+pydantic-core==2.6.3
 typing-extensions==4.7.1

--- a/src/overtake/decorator.py
+++ b/src/overtake/decorator.py
@@ -1,16 +1,42 @@
 from functools import wraps
 from typing import Callable, TypeVar
 
-from typing_extensions import ParamSpec
+from typing_extensions import ParamSpec, overload
 
 from overtake.overtake_class import OvertakenFunctionRegistry
+from overtake.runtime_type_checkers.umbrella import AVAILABLE_TYPE_CHECKERS
 
 T = TypeVar("T")
 P = ParamSpec("P")
 
 
+@overload
+def overtake(check_types_with: AVAILABLE_TYPE_CHECKERS) -> Callable:
+    ...
+
+
+@overload
 def overtake(func: Callable[P, T]) -> Callable[P, T]:
-    registry = OvertakenFunctionRegistry(func)
+    ...
+
+
+def overtake(func=None, *, runtime_type_checker: AVAILABLE_TYPE_CHECKERS = "basic"):
+    if func is None:
+        return lambda f: make_registry_and_return_wrapper(
+            f, runtime_type_checker=runtime_type_checker
+        )
+
+    return make_registry_and_return_wrapper(
+        func, runtime_type_checker=runtime_type_checker
+    )
+
+
+def make_registry_and_return_wrapper(
+    func: Callable[P, T], *, runtime_type_checker: AVAILABLE_TYPE_CHECKERS = "basic"
+) -> Callable[P, T]:
+    registry = OvertakenFunctionRegistry(
+        func, runtime_type_checker=runtime_type_checker
+    )
 
     @wraps(func)
     def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:

--- a/src/overtake/decorator.py
+++ b/src/overtake/decorator.py
@@ -11,16 +11,16 @@ P = ParamSpec("P")
 
 
 @overload
-def overtake(check_types_with: AVAILABLE_TYPE_CHECKERS) -> Callable:
+def overtake(func: Callable[P, T], /) -> Callable[P, T]:
     ...
 
 
 @overload
-def overtake(func: Callable[P, T]) -> Callable[P, T]:
+def overtake(*, runtime_type_checker: AVAILABLE_TYPE_CHECKERS = "basic") -> Callable:
     ...
 
 
-def overtake(func=None, *, runtime_type_checker: AVAILABLE_TYPE_CHECKERS = "basic"):
+def overtake(func=None, /, *, runtime_type_checker: AVAILABLE_TYPE_CHECKERS = "basic"):
     if func is None:
         return lambda f: make_registry_and_return_wrapper(
             f, runtime_type_checker=runtime_type_checker

--- a/src/overtake/overtake_class.py
+++ b/src/overtake/overtake_class.py
@@ -11,7 +11,7 @@ from overtake.incompatibility_reasons import (
     IncompatibilityReason,
 )
 from overtake.lazy_inspection import LazyOverloadsInspection
-from overtake.runtime_type_checkers.umbrella import check_type
+from overtake.runtime_type_checkers.umbrella import AVAILABLE_TYPE_CHECKERS, check_type
 
 
 class CompatibleOverloadNotFoundError(Exception):
@@ -23,9 +23,14 @@ P = ParamSpec("P")
 
 
 class OvertakenFunctionRegistry(Generic[P, T]):
-    def __init__(self, overtaken_function: Callable[P, T]):
+    def __init__(
+        self,
+        overtaken_function: Callable[P, T],
+        runtime_type_checker: AVAILABLE_TYPE_CHECKERS,
+    ):
         self.overtaken_function = overtaken_function
         self._lazy_inspection: Optional[LazyOverloadsInspection] = None
+        self.runtime_type_checker: AVAILABLE_TYPE_CHECKERS = runtime_type_checker
 
     @property
     def inspection_results(self) -> LazyOverloadsInspection:
@@ -93,7 +98,7 @@ class OvertakenFunctionRegistry(Generic[P, T]):
                 continue
 
             incompatibility_reason = check_type(
-                argument_value, type_hint, argument_name
+                argument_value, type_hint, argument_name, self.runtime_type_checker
             )
             if incompatibility_reason is None:
                 continue

--- a/src/overtake/runtime_type_checkers/basic.py
+++ b/src/overtake/runtime_type_checkers/basic.py
@@ -34,5 +34,6 @@ def check_type(
         raise TypeError(
             "The basic type checker built-in into overtake cannot handle type-checking"
             f" of {type_hint},you should try with beartype which has support for more"
-            " type hints. Run `pip install overtake[beartype]`."
+            " type hints. Run `pip install overtake[beartype]` "
+            "and use `@overtake(runtime_type_checker='beartype')`."
         )

--- a/src/overtake/runtime_type_checkers/beartype_is_bearable.py
+++ b/src/overtake/runtime_type_checkers/beartype_is_bearable.py
@@ -35,3 +35,11 @@ def check_type(
         return None
     else:
         return IncompatibilityTypeHintBeartype(argument_value, type_hint, argument_name)
+
+
+def verify_availability():
+    if beartype is None:
+        raise RuntimeError(
+            "You have used @overtake(runtime_type_checker='beartype') but beartype"
+            " is not installed on your system. Use 'pip install overtake[beartype]'."
+        )

--- a/src/overtake/runtime_type_checkers/pydantic_type_adapter.py
+++ b/src/overtake/runtime_type_checkers/pydantic_type_adapter.py
@@ -24,8 +24,8 @@ def check_type(
     argument_value: object, type_hint: object, argument_name: str
 ) -> Optional[IncompatibilityReason]:
     try:
-        pydantic.TypeAdapter(type_hint).validate_python(argument_value, strict=True)
-    except pydantic.ValidationError as e:
+        pydantic.TypeAdapter(type_hint).validate_python(argument_value, strict=True)  # type: ignore
+    except pydantic.ValidationError as e:  # type: ignore
         return IncompatibilityTypeHintPydantic(str(e), argument_name)
     return None
 

--- a/src/overtake/runtime_type_checkers/pydantic_type_adapter.py
+++ b/src/overtake/runtime_type_checkers/pydantic_type_adapter.py
@@ -27,6 +27,7 @@ def check_type(
         pydantic.TypeAdapter(type_hint).validate_python(argument_value, strict=True)
     except pydantic.ValidationError as e:
         return IncompatibilityTypeHintPydantic(str(e), argument_name)
+    return None
 
 
 def verify_availability():

--- a/src/overtake/runtime_type_checkers/pydantic_type_adapter.py
+++ b/src/overtake/runtime_type_checkers/pydantic_type_adapter.py
@@ -1,0 +1,38 @@
+from typing import Optional
+
+from overtake.incompatibility_reasons import IncompatibilityReason
+
+try:
+    import pydantic
+except ImportError:
+    pydantic = None  # type: ignore
+
+
+class IncompatibilityTypeHintPydantic(IncompatibilityReason):
+    def __init__(self, error_message: str, argument_name: str):
+        self.error_message = error_message
+        self.argument_name = argument_name
+
+    def __str__(self):
+        return (
+            f"There is a type hint mismatch for argument {self.argument_name}:"
+            f" {self.error_message}"
+        )
+
+
+def check_type(
+    argument_value: object, type_hint: object, argument_name: str
+) -> Optional[IncompatibilityReason]:
+    try:
+        pydantic.TypeAdapter(type_hint).validate_python(argument_value, strict=True)
+    except pydantic.ValidationError as e:
+        return IncompatibilityTypeHintPydantic(str(e), argument_name)
+
+
+def verify_availability():
+    if pydantic is None:
+        raise RuntimeError(
+            "You have used @overtake(runtime_type_checker='pydantic') but pydantic is"
+            " not installed on your system. Install overtake with 'pip install"
+            " overtake[pydantic]"
+        )

--- a/src/overtake/runtime_type_checkers/umbrella.py
+++ b/src/overtake/runtime_type_checkers/umbrella.py
@@ -1,19 +1,29 @@
-from typing import Optional
+from typing import Literal, Optional
 
 from overtake.incompatibility_reasons import IncompatibilityReason
 import overtake.runtime_type_checkers.basic
 import overtake.runtime_type_checkers.beartype_is_bearable
 
+AVAILABLE_TYPE_CHECKERS = Literal["basic", "beartype"]
+
 
 def check_type(
-    argument_value: object, type_hint: object, argument_name: str
+    argument_value: object,
+    type_hint: object,
+    argument_name: str,
+    runtime_type_checker: AVAILABLE_TYPE_CHECKERS,
 ) -> Optional[IncompatibilityReason]:
-    if overtake.runtime_type_checkers.beartype_is_bearable.beartype is None:
+    if runtime_type_checker == "basic":
         # Beartype is not installed
         return overtake.runtime_type_checkers.basic.check_type(
             argument_value, type_hint, argument_name
         )
-    else:
+    elif runtime_type_checker == "beartype":
         return overtake.runtime_type_checkers.beartype_is_bearable.check_type(
             argument_value, type_hint, argument_name
+        )
+    else:
+        raise ValueError(
+            f"Unknown runtime_type_checker. '{runtime_type_checker}' was provided, but"
+            " only 'basic' and 'beartype' are available"
         )

--- a/src/overtake/runtime_type_checkers/umbrella.py
+++ b/src/overtake/runtime_type_checkers/umbrella.py
@@ -14,11 +14,15 @@ def check_type(
     runtime_type_checker: AVAILABLE_TYPE_CHECKERS,
 ) -> Optional[IncompatibilityReason]:
     if runtime_type_checker == "basic":
-        # Beartype is not installed
         return overtake.runtime_type_checkers.basic.check_type(
             argument_value, type_hint, argument_name
         )
     elif runtime_type_checker == "beartype":
+        if overtake.runtime_type_checkers.beartype_is_bearable.beartype is None:
+            raise RuntimeError(
+                "You have used @overtake(runtime_type_checker='beartype') but beartype"
+                " is not installed on your system."
+            )
         return overtake.runtime_type_checkers.beartype_is_bearable.check_type(
             argument_value, type_hint, argument_name
         )

--- a/src/overtake/runtime_type_checkers/umbrella.py
+++ b/src/overtake/runtime_type_checkers/umbrella.py
@@ -3,6 +3,7 @@ from typing import Literal, Optional
 from overtake.incompatibility_reasons import IncompatibilityReason
 import overtake.runtime_type_checkers.basic
 import overtake.runtime_type_checkers.beartype_is_bearable
+import overtake.runtime_type_checkers.pydantic_type_adapter
 
 AVAILABLE_TYPE_CHECKERS = Literal["basic", "beartype"]
 
@@ -18,12 +19,13 @@ def check_type(
             argument_value, type_hint, argument_name
         )
     elif runtime_type_checker == "beartype":
-        if overtake.runtime_type_checkers.beartype_is_bearable.beartype is None:
-            raise RuntimeError(
-                "You have used @overtake(runtime_type_checker='beartype') but beartype"
-                " is not installed on your system."
-            )
+        overtake.runtime_type_checkers.beartype_is_bearable.verify_availability()
         return overtake.runtime_type_checkers.beartype_is_bearable.check_type(
+            argument_value, type_hint, argument_name
+        )
+    elif runtime_type_checker == "pydantic":
+        overtake.runtime_type_checkers.pydantic_type_adapter.verify_availability()
+        return overtake.runtime_type_checkers.pydantic_type_adapter.check_type(
             argument_value, type_hint, argument_name
         )
     else:

--- a/src/overtake/runtime_type_checkers/umbrella.py
+++ b/src/overtake/runtime_type_checkers/umbrella.py
@@ -5,7 +5,7 @@ import overtake.runtime_type_checkers.basic
 import overtake.runtime_type_checkers.beartype_is_bearable
 import overtake.runtime_type_checkers.pydantic_type_adapter
 
-AVAILABLE_TYPE_CHECKERS = Literal["basic", "beartype"]
+AVAILABLE_TYPE_CHECKERS = Literal["basic", "beartype", "pydantic"]
 
 
 def check_type(

--- a/tests/simple_use_cases_test.py
+++ b/tests/simple_use_cases_test.py
@@ -2,11 +2,13 @@ import sys
 from typing import List
 
 from overtake import CompatibleOverloadNotFoundError, OverloadsNotFoundError, overtake
+from overtake.runtime_type_checkers.umbrella import AVAILABLE_TYPE_CHECKERS
 import pytest
 import typing_extensions
 
 
-def test_one_argument():
+@pytest.mark.parametrize("runtime_type_checker", ["basic", "beartype", "pydantic"])
+def test_one_argument(runtime_type_checker: AVAILABLE_TYPE_CHECKERS):
     @typing_extensions.overload
     def my_function(my_var: int) -> int:
         return my_var + 1
@@ -15,7 +17,7 @@ def test_one_argument():
     def my_function(my_var: str) -> str:
         return my_var + "dododo"
 
-    @overtake(runtime_type_checker="beartype")
+    @overtake(runtime_type_checker=runtime_type_checker)
     def my_function(my_var):
         ...
 
@@ -23,7 +25,8 @@ def test_one_argument():
     assert my_function(3) == 4
 
 
-def test_multiple_arguments():
+@pytest.mark.parametrize("runtime_type_checker", ["basic", "beartype", "pydantic"])
+def test_multiple_arguments(runtime_type_checker: AVAILABLE_TYPE_CHECKERS):
     @typing_extensions.overload
     def my_function(unchanged_var: List[str], my_var: int) -> int:
         return my_var + 1
@@ -32,7 +35,7 @@ def test_multiple_arguments():
     def my_function(unchanged_var: List[str], my_var: str) -> str:
         return my_var + "dododo"
 
-    @overtake(runtime_type_checker="beartype")
+    @overtake(runtime_type_checker=runtime_type_checker)
     def my_function(unchanged_var, my_var):
         ...
 
@@ -40,7 +43,8 @@ def test_multiple_arguments():
     assert my_function([], 3) == 4
 
 
-def test_keyword_arguments():
+@pytest.mark.parametrize("runtime_type_checker", ["basic", "beartype", "pydantic"])
+def test_keyword_arguments(runtime_type_checker: AVAILABLE_TYPE_CHECKERS):
     @typing_extensions.overload
     def my_function(unchanged_var: List[str], my_var: int) -> int:
         return my_var + 1
@@ -49,7 +53,7 @@ def test_keyword_arguments():
     def my_function(unchanged_var: List[str], my_var: str) -> str:
         return my_var + "dododo"
 
-    @overtake(runtime_type_checker="beartype")
+    @overtake(runtime_type_checker=runtime_type_checker)
     def my_function(unchanged_var, my_var):
         ...
 
@@ -57,7 +61,8 @@ def test_keyword_arguments():
     assert my_function(my_var=3, unchanged_var=[]) == 4
 
 
-def test_variable_number_of_arguments():
+@pytest.mark.parametrize("runtime_type_checker", ["basic", "beartype", "pydantic"])
+def test_variable_number_of_arguments(runtime_type_checker: AVAILABLE_TYPE_CHECKERS):
     @typing_extensions.overload
     def my_function(my_var: int) -> int:
         return my_var + 1
@@ -66,7 +71,7 @@ def test_variable_number_of_arguments():
     def my_function(my_var: str, my_second: float = 4.1) -> str:
         return my_var + " new chars"
 
-    @overtake(runtime_type_checker="beartype")
+    @overtake(runtime_type_checker=runtime_type_checker)
     def my_function(my_var, my_second=4.1):
         ...
 
@@ -74,7 +79,10 @@ def test_variable_number_of_arguments():
     assert my_function(3) == 4
 
 
-def test_variable_number_of_arguments_same_types():
+@pytest.mark.parametrize("runtime_type_checker", ["basic", "beartype", "pydantic"])
+def test_variable_number_of_arguments_same_types(
+    runtime_type_checker: AVAILABLE_TYPE_CHECKERS,
+):
     @typing_extensions.overload
     def my_function(my_var: int) -> int:
         return my_var
@@ -83,7 +91,7 @@ def test_variable_number_of_arguments_same_types():
     def my_function(my_var: int, my_second: float) -> float:
         return my_var + my_second
 
-    @overtake(runtime_type_checker="beartype")
+    @overtake(runtime_type_checker=runtime_type_checker)
     def my_function(my_var, my_second=None):
         ...
 
@@ -94,7 +102,8 @@ def test_variable_number_of_arguments_same_types():
 @pytest.mark.skipif(
     sys.version_info < (3, 11), reason="typing.overload available in 3.11"
 )
-def test_regular_typing_overload():
+@pytest.mark.parametrize("runtime_type_checker", ["basic", "beartype", "pydantic"])
+def test_regular_typing_overload(runtime_type_checker: AVAILABLE_TYPE_CHECKERS):
     from typing import overload
 
     @overload
@@ -105,7 +114,7 @@ def test_regular_typing_overload():
     def my_function(my_var: str) -> str:
         return my_var + "dododo"
 
-    @overtake(runtime_type_checker="beartype")
+    @overtake(runtime_type_checker=runtime_type_checker)
     def my_function(my_var):
         ...
 
@@ -116,7 +125,10 @@ def test_regular_typing_overload():
 @pytest.mark.skipif(
     sys.version_info >= (3, 11), reason="typing.overloads supported after 3.11"
 )
-def test_regular_typing_overload_with_old_python_versions():
+@pytest.mark.parametrize("runtime_type_checker", ["basic", "beartype", "pydantic"])
+def test_regular_typing_overload_with_old_python_versions(
+    runtime_type_checker: AVAILABLE_TYPE_CHECKERS,
+):
     from typing import overload
 
     @overload
@@ -127,7 +139,7 @@ def test_regular_typing_overload_with_old_python_versions():
     def my_function(my_var: str) -> str:
         return my_var + "dododo"
 
-    @overtake(runtime_type_checker="beartype")
+    @overtake(runtime_type_checker=runtime_type_checker)
     def my_function(my_var):
         ...
 
@@ -148,7 +160,8 @@ def test_regular_typing_overload_with_old_python_versions():
     sys.version_info < (3, 11),
     reason="We want to make sure we don't give wrong hints about the error",
 )
-def test_forgotten_overload():
+@pytest.mark.parametrize("runtime_type_checker", ["basic", "beartype", "pydantic"])
+def test_forgotten_overload(runtime_type_checker: AVAILABLE_TYPE_CHECKERS):
     def my_function(my_var: int) -> int:
         return my_var + 1
 
@@ -204,7 +217,8 @@ def test_no_compatible_overload_found():
     )
 
 
-def test_force_single_argument():
+@pytest.mark.parametrize("runtime_type_checker", ["basic", "beartype", "pydantic"])
+def test_force_single_argument(runtime_type_checker: AVAILABLE_TYPE_CHECKERS):
     from typing_extensions import overload
 
     @overload
@@ -215,7 +229,7 @@ def test_force_single_argument():
     def find_user_balance(user_id: int) -> int:
         return 50
 
-    @overtake(runtime_type_checker="beartype")
+    @overtake(runtime_type_checker=runtime_type_checker)
     def find_user_balance(*, user_id=None, name=None):
         ...
 

--- a/tests/simple_use_cases_test.py
+++ b/tests/simple_use_cases_test.py
@@ -15,7 +15,7 @@ def test_one_argument():
     def my_function(my_var: str) -> str:
         return my_var + "dododo"
 
-    @overtake
+    @overtake(runtime_type_checker="beartype")
     def my_function(my_var):
         ...
 
@@ -32,7 +32,7 @@ def test_multiple_arguments():
     def my_function(unchanged_var: List[str], my_var: str) -> str:
         return my_var + "dododo"
 
-    @overtake
+    @overtake(runtime_type_checker="beartype")
     def my_function(unchanged_var, my_var):
         ...
 
@@ -49,7 +49,7 @@ def test_keyword_arguments():
     def my_function(unchanged_var: List[str], my_var: str) -> str:
         return my_var + "dododo"
 
-    @overtake
+    @overtake(runtime_type_checker="beartype")
     def my_function(unchanged_var, my_var):
         ...
 
@@ -66,7 +66,7 @@ def test_variable_number_of_arguments():
     def my_function(my_var: str, my_second: float = 4.1) -> str:
         return my_var + " new chars"
 
-    @overtake
+    @overtake(runtime_type_checker="beartype")
     def my_function(my_var, my_second=4.1):
         ...
 
@@ -83,7 +83,7 @@ def test_variable_number_of_arguments_same_types():
     def my_function(my_var: int, my_second: float) -> float:
         return my_var + my_second
 
-    @overtake
+    @overtake(runtime_type_checker="beartype")
     def my_function(my_var, my_second=None):
         ...
 
@@ -105,7 +105,7 @@ def test_regular_typing_overload():
     def my_function(my_var: str) -> str:
         return my_var + "dododo"
 
-    @overtake
+    @overtake(runtime_type_checker="beartype")
     def my_function(my_var):
         ...
 
@@ -127,7 +127,7 @@ def test_regular_typing_overload_with_old_python_versions():
     def my_function(my_var: str) -> str:
         return my_var + "dododo"
 
-    @overtake
+    @overtake(runtime_type_checker="beartype")
     def my_function(my_var):
         ...
 
@@ -155,7 +155,7 @@ def test_forgotten_overload():
     def my_function(my_var: str) -> str:
         return my_var + "dododo"
 
-    @overtake
+    @overtake(runtime_type_checker="beartype")
     def my_function(my_var):
         ...
 
@@ -184,7 +184,7 @@ def test_no_compatible_overload_found():
     def my_function(my_var: str, second_var: float) -> str:
         return my_var
 
-    @overtake
+    @overtake(runtime_type_checker="beartype")
     def my_function(my_var, second_var=None):
         ...
 
@@ -215,7 +215,7 @@ def test_force_single_argument():
     def find_user_balance(user_id: int) -> int:
         return 50
 
-    @overtake
+    @overtake(runtime_type_checker="beartype")
     def find_user_balance(*, user_id=None, name=None):
         ...
 

--- a/tests/test_args_kwargs.py
+++ b/tests/test_args_kwargs.py
@@ -15,7 +15,7 @@ def test_args():
     def my_function(*args: str) -> str:
         return "".join(args)
 
-    @overtake
+    @overtake(runtime_type_checker="beartype")
     def my_function(*args):
         ...
 
@@ -38,7 +38,7 @@ def test_kwargs():
     def my_function(**kwargs: str) -> str:
         return "".join(kwargs.values())
 
-    @overtake
+    @overtake(runtime_type_checker="beartype")
     def my_function(**kwargs):
         ...
 
@@ -69,7 +69,7 @@ def test_kwargs_with_typedict():
     def my_function(**kwargs: Unpack[MyDict2]) -> str:
         return kwargs["c"]
 
-    @overtake
+    @overtake(runtime_type_checker="beartype")
     def my_function(**kwargs):
         ...
 

--- a/tests/test_args_kwargs.py
+++ b/tests/test_args_kwargs.py
@@ -1,12 +1,14 @@
 from typing import TypedDict
 
 from overtake import overtake
+from overtake.runtime_type_checkers.umbrella import AVAILABLE_TYPE_CHECKERS
 import pytest
 import typing_extensions
 from typing_extensions import Unpack
 
 
-def test_args():
+@pytest.mark.parametrize("runtime_type_checker", ["beartype", "pydantic"])
+def test_args(runtime_type_checker: AVAILABLE_TYPE_CHECKERS):
     @typing_extensions.overload
     def my_function(*args: int) -> int:
         return sum(args)
@@ -15,7 +17,7 @@ def test_args():
     def my_function(*args: str) -> str:
         return "".join(args)
 
-    @overtake(runtime_type_checker="beartype")
+    @overtake(runtime_type_checker=runtime_type_checker)
     def my_function(*args):
         ...
 

--- a/tests/test_args_kwargs.py
+++ b/tests/test_args_kwargs.py
@@ -1,10 +1,8 @@
-from typing import TypedDict
-
 from overtake import overtake
 from overtake.runtime_type_checkers.umbrella import AVAILABLE_TYPE_CHECKERS
 import pytest
 import typing_extensions
-from typing_extensions import Unpack
+from typing_extensions import TypedDict, Unpack
 
 
 @pytest.mark.parametrize("runtime_type_checker", ["beartype", "pydantic"])
@@ -25,13 +23,8 @@ def test_args(runtime_type_checker: AVAILABLE_TYPE_CHECKERS):
     assert my_function(3, 3) == 6
 
 
-@pytest.mark.xfail(
-    reason=(
-        "beartype doesn't support checking dicts. See"
-        " https://github.com/beartype/beartype/issues/167"
-    )
-)
-def test_kwargs():
+@pytest.mark.parametrize("runtime_type_checker", ["pydantic"])
+def test_kwargs(runtime_type_checker: AVAILABLE_TYPE_CHECKERS):
     @typing_extensions.overload
     def my_function(**kwargs: int) -> int:
         return sum(kwargs.values())
@@ -40,7 +33,7 @@ def test_kwargs():
     def my_function(**kwargs: str) -> str:
         return "".join(kwargs.values())
 
-    @overtake(runtime_type_checker="beartype")
+    @overtake(runtime_type_checker=runtime_type_checker)
     def my_function(**kwargs):
         ...
 
@@ -48,13 +41,8 @@ def test_kwargs():
     assert my_function(a=3, b=3) == 6
 
 
-@pytest.mark.xfail(
-    reason=(
-        "beartype doesn't support checking TypedDict. Once it does, then this should"
-        " work."
-    )
-)
-def test_kwargs_with_typedict():
+@pytest.mark.parametrize("runtime_type_checker", ["pydantic"])
+def test_kwargs_with_typedict(runtime_type_checker: AVAILABLE_TYPE_CHECKERS):
     class MyDict1(TypedDict):
         a: int
         b: int
@@ -71,7 +59,7 @@ def test_kwargs_with_typedict():
     def my_function(**kwargs: Unpack[MyDict2]) -> str:
         return kwargs["c"]
 
-    @overtake(runtime_type_checker="beartype")
+    @overtake(runtime_type_checker=runtime_type_checker)
     def my_function(**kwargs):
         ...
 


### PR DESCRIPTION
There will be three type checkers available:
* "basic": built-in overtake, uses `isinstance`.
* "beartype" Uses `is_bearable` and `die_if_unbearable`.
* "pydantic" Uses pydantic v2, not implemented yet.