### PR TITLE
Add support for unpacking tuples in args annotation 

### DIFF
--- a/src/overtake/lazy_inspection.py
+++ b/src/overtake/lazy_inspection.py
@@ -68,26 +68,23 @@ def _find_arguments_to_check(
     meaning the dispatching is decided by the number of arguments
     provided.
     """
-    kwargs_unpack_present = False
+    variadic_unpack_present = False
     all_arguments = set()
     arguments_to_check = set()
     found_types = {}
-    for overloaded_implementation, signature in implementations:
+    for _, signature in implementations:
         for argument_name, argument in signature.parameters.items():
             all_arguments.add(argument_name)
             if (
-                argument.kind == argument.VAR_KEYWORD
-                and (
-                    get_origin(argument.annotation) == Unpack
-                    or (isinstance(argument.annotation, str) and "Unpack" in argument.annotation)
-                )
+                get_origin(argument.annotation) == Unpack
+                or (isinstance(argument.annotation, str) and "Unpack" in argument.annotation)
             ):
                 # We don't know yet which arguments this unpack might conflict with so we check all
-                kwargs_unpack_present = True
+                variadic_unpack_present = True
             if argument_name not in found_types:
                 found_types[argument_name] = argument.annotation
             else:
                 if argument.annotation != found_types[argument_name]:
                     # it changed, let's check it later
                     arguments_to_check.add(argument_name)
-    return all_arguments if kwargs_unpack_present else arguments_to_check
+    return all_arguments if variadic_unpack_present else arguments_to_check

--- a/src/overtake/overtake_class.py
+++ b/src/overtake/overtake_class.py
@@ -85,9 +85,14 @@ class OvertakenFunctionRegistry(Generic[P, T]):
             type_hint = signature.parameters[argument_name].annotation
             parameter = signature.parameters[argument_name]
             if parameter.kind == inspect.Parameter.VAR_POSITIONAL:
-                # in wonder if we should take typing.Unpack into account here. For now, let's
-                # say that we ignore it.
-                type_hint = Tuple[type_hint, ...]
+                if typing.get_origin(type_hint) == Unpack:
+                    unpacked = typing.get_args(type_hint)[0]
+                    if typing.get_origin(unpacked) == tuple:
+                        type_hint = unpacked
+                    else:
+                        type_hint = tuple[unpacked, ...]
+                else:
+                    type_hint = tuple[type_hint, ...]
             elif parameter.kind == inspect.Parameter.VAR_KEYWORD:
                 if typing.get_origin(type_hint) == Unpack:
                     type_hint = typing.get_args(type_hint)[0]

--- a/tests/simple_use_cases_test.py
+++ b/tests/simple_use_cases_test.py
@@ -272,3 +272,23 @@ def test_force_single_argument(runtime_type_checker: AVAILABLE_TYPE_CHECKERS):
 
     assert find_user_balance(name="Julie") == 40
     assert find_user_balance(user_id=14) == 50
+
+
+@pytest.mark.parametrize("runtime_type_checker", ["basic", "beartype", "pydantic"])
+def test_positional_argument_different_type_and_name(runtime_type_checker: AVAILABLE_TYPE_CHECKERS):
+    from typing_extensions import overload
+
+    @overload
+    def find_user_balance(name: str, /) -> int:
+        return 40
+
+    @overload
+    def find_user_balance(user_id: int, /) -> int:
+        return 50
+
+    @overtake(runtime_type_checker=runtime_type_checker)
+    def find_user_balance(name_or_id: str | int) -> int:
+        ...
+
+    assert find_user_balance("Julie") == 40
+    assert find_user_balance(14) == 50

--- a/tests/test_args_kwargs.py
+++ b/tests/test_args_kwargs.py
@@ -23,6 +23,25 @@ def test_args(runtime_type_checker: AVAILABLE_TYPE_CHECKERS):
     assert my_function(3, 3) == 6
 
 
+@pytest.mark.parametrize("runtime_type_checker", ["beartype"])
+def test_args_with_unpack(runtime_type_checker: AVAILABLE_TYPE_CHECKERS):
+    @typing_extensions.overload
+    def my_function(*args: Unpack[tuple[int, int, int]]) -> str:
+        red, green, blue = args
+        return f"#{red:02x}{green:02x}{blue:02x}"
+
+    @typing_extensions.overload
+    def my_function(*args: Unpack[tuple[str, float, int]]) -> str:
+        return f"{args[0]}{args[1] * args[2]}"
+
+    @overtake(runtime_type_checker=runtime_type_checker)
+    def my_function(*args) -> str:
+        ...
+
+    assert my_function(0, 255, 128) == "#00ff80"
+    assert my_function("Hello", 1.23, 2) == "Hello2.46"
+
+
 @pytest.mark.parametrize("runtime_type_checker", ["pydantic"])
 def test_kwargs(runtime_type_checker: AVAILABLE_TYPE_CHECKERS):
     @typing_extensions.overload

--- a/tests/test_args_kwargs.py
+++ b/tests/test_args_kwargs.py
@@ -16,7 +16,7 @@ def test_args(runtime_type_checker: AVAILABLE_TYPE_CHECKERS):
         return "".join(args)
 
     @overtake(runtime_type_checker=runtime_type_checker)
-    def my_function(*args):
+    def my_function(*args) -> str | int:
         ...
 
     assert my_function("5153", "dododo") == "5153dododo"
@@ -34,7 +34,7 @@ def test_kwargs(runtime_type_checker: AVAILABLE_TYPE_CHECKERS):
         return "".join(kwargs.values())
 
     @overtake(runtime_type_checker=runtime_type_checker)
-    def my_function(**kwargs):
+    def my_function(**kwargs) -> str | int:
         ...
 
     assert my_function(a="5153", b="dododo") == "5153dododo"
@@ -56,11 +56,11 @@ def test_kwargs_with_typedict(runtime_type_checker: AVAILABLE_TYPE_CHECKERS):
         return kwargs["a"]
 
     @typing_extensions.overload
-    def my_function(**kwargs: Unpack[MyDict2]) -> str:
+    def my_function(**kwargs: Unpack[MyDict2]) -> int:
         return kwargs["c"]
 
     @overtake(runtime_type_checker=runtime_type_checker)
-    def my_function(**kwargs):
+    def my_function(**kwargs) -> int:
         ...
 
     assert my_function(a=1, b=2) == 1

--- a/tests/test_args_kwargs.py
+++ b/tests/test_args_kwargs.py
@@ -61,7 +61,7 @@ def test_kwargs(runtime_type_checker: AVAILABLE_TYPE_CHECKERS):
 
 
 @pytest.mark.parametrize("runtime_type_checker", ["pydantic"])
-def test_kwargs_with_typedict(runtime_type_checker: AVAILABLE_TYPE_CHECKERS):
+def test_kwargs_with_typeddict(runtime_type_checker: AVAILABLE_TYPE_CHECKERS):
     class MyDict1(TypedDict):
         a: int
         b: int
@@ -84,3 +84,25 @@ def test_kwargs_with_typedict(runtime_type_checker: AVAILABLE_TYPE_CHECKERS):
 
     assert my_function(a=1, b=2) == 1
     assert my_function(c=3, d=4) == 3
+
+
+@pytest.mark.parametrize("runtime_type_checker", ["pydantic"])
+def test_kwargs_with_one_typeddict(runtime_type_checker: AVAILABLE_TYPE_CHECKERS):
+    class MyDict1(TypedDict):
+        a: int
+        b: str
+
+    @typing_extensions.overload
+    def my_function(a: int, b: int) -> int:
+        return a
+
+    @typing_extensions.overload
+    def my_function(**kwargs: Unpack[MyDict1]) -> str:
+        return kwargs["b"]
+
+    @overtake(runtime_type_checker="pydantic")
+    def my_function(a: int, b: int | str) -> int | str:
+        ...
+
+    assert my_function(a=1, b=2) == 1
+    assert my_function(a=3, b="Hello") == "Hello"

--- a/tests/test_args_kwargs.py
+++ b/tests/test_args_kwargs.py
@@ -42,6 +42,25 @@ def test_args_with_unpack(runtime_type_checker: AVAILABLE_TYPE_CHECKERS):
     assert my_function("Hello", 1.23, 2) == "Hello2.46"
 
 
+@pytest.mark.parametrize("runtime_type_checker", ["beartype"])
+def test_args_with_unpack_collision(runtime_type_checker: AVAILABLE_TYPE_CHECKERS):
+    @typing_extensions.overload
+    def my_function(*args: Unpack[tuple[int, int, int]]) -> str:
+        red, green, blue = args
+        return f"#{red:02x}{green:02x}{blue:02x}"
+
+    @typing_extensions.overload
+    def my_function(arg1: int, arg2: str, arg3: int, /) -> str:
+        return f"{arg1} {arg2} {arg3}"
+
+    @overtake(runtime_type_checker=runtime_type_checker)
+    def my_function(*args) -> str:
+        ...
+
+    assert my_function(0, 255, 128) == "#00ff80"
+    assert my_function(1, "Hello", 2) == "1 Hello 2"
+
+
 @pytest.mark.parametrize("runtime_type_checker", ["pydantic"])
 def test_kwargs(runtime_type_checker: AVAILABLE_TYPE_CHECKERS):
     @typing_extensions.overload


### PR DESCRIPTION
Implementation and tests for supporting unpacking tuples for `*args` annotations.

I've sneaked in some typing fixes for all tests which now pass pyright:
- missing return annotations.
- Change to keyword arguments where names where incompatible.
- Removed a duplicated test.

Please let me know if you want me to do any changes.